### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/azure_ad_login_without_mfa.yml
+++ b/rules/azure_ad_login_without_mfa.yml
@@ -12,7 +12,6 @@ description: |-
   2. If legitimate, request the user enable 2FA.
   3. If not legitimate, rotate the credentials.
   4. Review all user accounts to ensure MFA is enabled.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_ad_sign_in_from_aadinternals_default_user_agent.yml
+++ b/rules/azure_ad_sign_in_from_aadinternals_default_user_agent.yml
@@ -12,7 +12,6 @@ description: |-
   2. If the investigation shows this tool is unauthorized, initiate your incident response process.
       * If necessary, disable the affected identity and revoke any sign-in sessions.
       * Examine any actions taken by the identity during the relevant time frame.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:(azure microsoft_365)

--- a/rules/azure_ad_sign_in_from_azurehound_default_user_agent.yml
+++ b/rules/azure_ad_sign_in_from_azurehound_default_user_agent.yml
@@ -12,7 +12,6 @@ description: |-
   2. If the triage indicates that this tool is unauthorized, initiate your company's incident response process and investigation.
       * If necessary, disable the affected identity and revoke any sign-in sessions.
       * Investigate any actions taken by the identity during the identified time frame.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:(azure microsoft_365)

--- a/rules/azure_administrative_unit_created.yml
+++ b/rules/azure_administrative_unit_created.yml
@@ -14,7 +14,6 @@ description: |-
   1. Review if the organization uses administrative units.
   2. Investigate any anomalous activity associated with the user creating an administrative unit.
   3. Determine if there is a legitimate reason for the user's action in creating an administrative unit.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_administrative_unit_modified.yml
+++ b/rules/azure_administrative_unit_modified.yml
@@ -14,7 +14,6 @@ description: |-
   1. Check if your organization uses administrative units.
   2. Investigate any anomalous activity by the user modifying an administrative unit.
   3. Assess whether there is a legitimate reason for the modification.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_diagnostic_setting_deleted_or_disabled.yml
+++ b/rules/azure_diagnostic_setting_deleted_or_disabled.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Inspect the diagnostic setting resource found in the resource ID.
   2. Verify the user to determine if the removal of the resource is legitimate.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_disk_export_uri_created.yml
+++ b/rules/azure_disk_export_uri_created.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Verify the disk has a legitimate reason for being exported.
   2. If the activity is not expected, investigate the activity around the IP creating the export URI.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_firewall_threat_intelligence_alert.yml
+++ b/rules/azure_firewall_threat_intelligence_alert.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Inspect the threat intelligence log.
   2. Investigate the activity from the identified IP address.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_frontdoor_waf_blocked_a_request.yml
+++ b/rules/azure_frontdoor_waf_blocked_a_request.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Inspect whether this request should have been blocked.
   2. Navigate to the IP dashboard and review other requests made by this IP address.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_frontdoor_waf_logged_a_request.yml
+++ b/rules/azure_frontdoor_waf_logged_a_request.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Inspect whether this request should have been blocked or not.
   2. Navigate to the IP dashboard and review other requests from this IP address.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_network_security_group_open_to_the_world.yml
+++ b/rules/azure_network_security_group_open_to_the_world.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Inspect which Virtual Machines are associated with this security group.
   2. Determine whether this security group and the VMs should permit inbound traffic from all IP addresses.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_network_security_groups_or_rules_created_modified_or_deleted.yml
+++ b/rules/azure_network_security_groups_or_rules_created_modified_or_deleted.yml
@@ -15,7 +15,6 @@ description: |
 
   ## Triage and response
   Inspect the security group or rule to determine if it exposes any Azure resources inappropriately.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_new_owner_added_for_service_principal.yml
+++ b/rules/azure_new_owner_added_for_service_principal.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Confirm that the user has been added to a service principal in the target resources.
   2. Verify with the user to determine if the owner addition is legitimate.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_new_owner_added_to_azure_active_directory_application.yml
+++ b/rules/azure_new_owner_added_to_azure_active_directory_application.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and Response
   1. Review evidence of anomalous activity for the user being added as an owner for the Active Directory application.
   2. Determine if there is a legitimate reason for the user being added to the application.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_new_service_principal_created.yml
+++ b/rules/azure_new_service_principal_created.yml
@@ -13,7 +13,6 @@ description: |-
 
   1. Inspect the new service principal in the target resources.
   2. Verify with the user to determine if the service principal is legitimate.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_policy_assignment_created.yml
+++ b/rules/azure_policy_assignment_created.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Inspect the policy assignment to determine if an unsolicited change was made to any Azure resources.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_restricted_management_administrative_unit_created.yml
+++ b/rules/azure_restricted_management_administrative_unit_created.yml
@@ -14,7 +14,6 @@ description: |-
   1. Confirm if restricted administrative units are utilized by the organization.
   2. Investigate any anomalous activity by the user who created the restricted administrative unit.
   3. Assess if there is a valid reason for the creation of the restricted administrative unit by the user.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_service_principal_was_assigned_a_role.yml
+++ b/rules/azure_service_principal_was_assigned_a_role.yml
@@ -20,7 +20,6 @@ description: |-
     * Remove unauthorized app registration or service principal.
     * Investigate other activities performed by the source IP.
     * Investigate other activities performed by the user.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_snapshot_export_uri_created.yml
+++ b/rules/azure_snapshot_export_uri_created.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and Response
   1. Verify the snapshot has a legitimate reason for being exported.
   2. If the activity is unexpected, investigate the IP address that created the export URL.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_sql_server_firewall_rules_created_or_modified.yml
+++ b/rules/azure_sql_server_firewall_rules_created_or_modified.yml
@@ -13,7 +13,6 @@ description: |-
 
   ## Triage and response
   Inspect the security rule to determine if it exposes any Azure resources that should remain private.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_user_added_to_restricted_management_administrative_unit.yml
+++ b/rules/azure_user_added_to_restricted_management_administrative_unit.yml
@@ -14,7 +14,6 @@ description: |-
   1. Confirm if restricted administrative units are utilized by the organization.
   2. Investigate any anomalous activity related to the user being added to the restricted administrative unit.
   3. Assess if there is a valid reason for the user's addition to the restricted administrative unit.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_user_granted_scoped_role_assignment_over_administrative_unit.yml
+++ b/rules/azure_user_granted_scoped_role_assignment_over_administrative_unit.yml
@@ -14,7 +14,6 @@ description: |-
   1. Verify if restricted administrative units are utilized by the organization.
   2. Investigate any anomalous activity related to the user granted role assignment to the restricted administrative unit.
   3. Assess whether there is a legitimate reason for the user's role assignment to the restricted administrative unit.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_user_invited_an_external_user.yml
+++ b/rules/azure_user_invited_an_external_user.yml
@@ -9,7 +9,6 @@ description: |-
 
   ## Triage and response
   Review the invitation and its recipient to confirm their validity.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_user_ran_command_on_container_instance.yml
+++ b/rules/azure_user_ran_command_on_container_instance.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Verify that the user should be executing commands on the container.
   2. If the activity is not expected, investigate related activity around the container.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_user_removed_from_restricted_administrative_unit.yml
+++ b/rules/azure_user_removed_from_restricted_administrative_unit.yml
@@ -14,7 +14,6 @@ description: |-
   1. Check if restricted administrative units are in use by the organization.
   2. Investigate any suspicious activity for the user being removed.
   3. Assess if there is a valid reason for the user's removal from the restricted administrative unit.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_user_viewed_cosmosdb_access_keys.yml
+++ b/rules/azure_user_viewed_cosmosdb_access_keys.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Verify that the user should be viewing the access key for the specified CosmoDB database.
   2. If the activity is not expected, investigate the related activities around the CosmoDB database.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure

--- a/rules/azure_user_viewed_cosmosdb_connection_string.yml
+++ b/rules/azure_user_viewed_cosmosdb_connection_string.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Verify that the user should be viewing the connection string for the specified CosmoDB database.
   2. If the activity is not expected, investigate the activity related to the CosmoDB.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:azure


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.